### PR TITLE
Add serializeMessage and serializedMessageSize

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "wasm-cbuf",
   "version": "2.2.0",
   "main": "dist/index.js",
+  "description": "Verdant CBUF IDL and message serialization compiled to WebAssembly",
   "license": "Apache-2.0",
   "author": {
     "name": "Metaverse Industries LLC",
@@ -22,7 +23,8 @@
   "devDependencies": {
     "eslint": "8.34.0",
     "mocha": "10.2.0",
-    "prettier": "2.8.4"
+    "prettier": "2.8.4",
+    "typescript": "5.2.2"
   },
   "dependencies": {
     "@foxglove/message-definition": "^0.2.0"

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -78,8 +78,9 @@ declare module "wasm-cbuf" {
      * deserialize the buffer into a JavaScript object representing a single non-naked struct
      * message, which includes a message header and message data.
      *
-     * @param hashMap A map of hash values to message definitions obtained from `parseCBufSchema()`
-     *   then `schemaMapToHashMap()`.
+     * @param schemaMap A map of fully qualified message names to message definitions obtained from
+     *   `parseCBufSchema()`.
+     * @param hashMap A map of hash values to message definitions obtained `schemaMapToHashMap()`.
      * @param data The byte buffer to deserialize from.
      * @param offset Optional byte offset into the buffer to deserialize from.
      * @returns A JavaScript object representing the deserialized message header fields and message
@@ -91,6 +92,36 @@ declare module "wasm-cbuf" {
       data: ArrayBufferView,
       offset?: number,
     ) => CbufMessage
+    /**
+     * Given a schema map and hash map, and a `CbufMessage` object, serialize the message into a
+     * byte buffer.
+     *
+     * @param schemaMap A map of fully qualified message names to message definitions obtained from
+     *   `parseCBufSchema()`.
+     * @param hashMap A map of hash values to message definitions obtained `schemaMapToHashMap()`.
+     * @param message
+     * @returns A byte buffer containing the serialized message header and message data.
+     */
+    serializeMessage: (
+      schemaMap: CbufMessageMap,
+      hashMap: CbufHashMap,
+      message: CbufMessage,
+    ) => ArrayBuffer
+    /**
+     * Given a schema map and hash map, and a `CbufMessage` object, return the size of the
+     * serialized message in bytes.
+     *
+     * @param schemaMap A map of fully qualified message names to message definitions obtained from
+     *   `parseCBufSchema()`.
+     * @param hashMap A map of hash values to message definitions obtained `schemaMapToHashMap()`.
+     * @param message
+     * @returns The size of the serialized message in bytes.
+     */
+    serializedMessageSize: (
+      schemaMap: CbufMessageMap,
+      hashMap: CbufHashMap,
+      message: CbufMessage,
+    ) => number
   }
 
   const cbuf: Cbuf

--- a/yarn.lock
+++ b/yarn.lock
@@ -908,6 +908,11 @@ type-fest@^0.20.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
+typescript@5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
+
 uri-js@^4.2.2:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"


### PR DESCRIPTION
**User-facing changes**
- Adds `serializeMessage()` for converting JavaScript object representations of deserialized CBUF messages to serialized `ArrayBuffer` payloads
- Adds `serializedMessageSize()` for determining the size of the ArrayBuffer that would be produced by `serializeMessage()`